### PR TITLE
feat: next token id tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Advanced Sample Hardhat Project
+
+This project demonstrates an advanced Hardhat use case, integrating other tools commonly used alongside Hardhat in the ecosystem.
+
+The project comes with a sample contract, a test for that contract, a sample script that deploys that contract, and an example of a task implementation, which simply lists the available accounts. It also comes with a variety of other tools, preconfigured to work with the project code.
+
+Try running some of the following tasks:
+
+```shell
+npx hardhat accounts
+npx hardhat compile
+npx hardhat clean
+npx hardhat test
+npx hardhat node
+npx hardhat help
+REPORT_GAS=true npx hardhat test
+npx hardhat coverage
+npx hardhat run scripts/deploy.ts
+TS_NODE_FILES=true npx ts-node scripts/deploy.ts
+npx eslint '**/*.{js,ts}'
+npx eslint '**/*.{js,ts}' --fix
+npx prettier '**/*.{json,sol,md}' --check
+npx prettier '**/*.{json,sol,md}' --write
+npx solhint 'contracts/**/*.sol'
+npx solhint 'contracts/**/*.sol' --fix
+```
+
+# Etherscan verification
+
+To try out Etherscan verification, you first need to deploy a contract to an Ethereum network that's supported by Etherscan, such as Ropsten.
+
+In this project, copy the .env.example file to a file named .env, and then edit it to fill in the details. Enter your Etherscan API key, your Ropsten node URL (eg from Alchemy), and the private key of the account which will send the deployment transaction. With a valid .env file in place, first deploy your contract:
+
+```shell
+hardhat run --network ropsten scripts/deploy.ts
+```
+
+Then, copy the deployment address and paste it in to replace `DEPLOYED_CONTRACT_ADDRESS` in this command:
+
+```shell
+npx hardhat verify --network ropsten DEPLOYED_CONTRACT_ADDRESS "Hello, Hardhat!"
+```
+
+# Performance optimizations
+
+For faster runs of your tests and scripts, consider skipping ts-node's type checking by setting the environment variable `TS_NODE_TRANSPILE_ONLY` to `1` in hardhat's environment. For more details see [the documentation](https://hardhat.org/guides/typescript.html#performance-optimizations).

--- a/contracts/VHC1155.sol
+++ b/contracts/VHC1155.sol
@@ -4,13 +4,17 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
 import "./ERC2981PerTokenRoyalties.sol";
 
 /**
  * @title VHC1155
- * @dev Vault Hill City's ERC1155 contract
+ * @dev Vault Hill's ERC1155 contract
  */
 contract VHC1155 is ERC1155, Ownable, ERC1155Supply, ERC2981PerTokenRoyalties {
+    using Counters for Counters.Counter;
+    Counters.Counter private _tokenIds;
+
     constructor(string memory uri_) ERC1155(uri_) {}
 
     mapping(uint256 => address) internal _tokenOwners;
@@ -35,6 +39,14 @@ contract VHC1155 is ERC1155, Ownable, ERC1155Supply, ERC2981PerTokenRoyalties {
     function setURI(string memory newUri) public onlyOwner {
         _setURI(newUri);
     }
+    
+    /**
+     * @dev Gets the ID of the next free token ID
+     */
+    function nextTokenId() public view returns (uint256) {
+        return _tokenIds.current();
+    }
+
 
     /**
      * @dev Mint amount token of type `id` to `to`
@@ -52,12 +64,18 @@ contract VHC1155 is ERC1155, Ownable, ERC1155Supply, ERC2981PerTokenRoyalties {
         uint256 royaltyValue
     ) external {
         require(_tokenOwners[id] == address(0x0) || _tokenOwners[id] == msg.sender, "VHC1155: only token owner can mint");
+        
+        uint256 tokenId = id;
 
-        _mint(to, id, amount, "");
-        _tokenOwners[id] = msg.sender;
-
+        if (_tokenOwners[id] == address(0x0)) {
+            // If token ID is empty, use next avaible ID
+            tokenId = _tokenIds.current();
+            _tokenOwners[tokenId] = msg.sender;
+            _tokenIds.increment();
+        }
+        _mint(to, tokenId, amount, "");
         if (royaltyValue > 0) {
-            _setTokenRoyalty(id, royaltyRecipient, royaltyValue);
+            _setTokenRoyalty(tokenId, royaltyRecipient, royaltyValue);
         }
     }
 
@@ -81,19 +99,28 @@ contract VHC1155 is ERC1155, Ownable, ERC1155Supply, ERC2981PerTokenRoyalties {
                 ids.length == royaltyValues.length,
             "ERC1155: Arrays length mismatch"
         );
+
+        uint256[] memory newTokenIds = new uint256[](ids.length);
         for (uint256 i = 0; i < ids.length; i++) {
             require(_tokenOwners[ids[i]] == address(0x0) || _tokenOwners[ids[i]] == msg.sender, "VHC1155: only token owner can mint");
+            if (_tokenOwners[ids[i]] == address(0x0)) {
+                newTokenIds[i] = _tokenIds.current();
+                _tokenIds.increment();
+            } else {
+                newTokenIds[i] = ids[i];
+            }
         }
 
-        _mintBatch(to, ids, amounts, "");
+        _mintBatch(to, newTokenIds, amounts, "");
 
-        for (uint256 i; i < ids.length; i++) {
-            if (_tokenOwners[ids[i]] == address(0x0)) {
-                _tokenOwners[ids[i]] = msg.sender;
+        // Update _tokenOwners and royalties if required
+        for (uint256 i; i < newTokenIds.length; i++) {
+            if (_tokenOwners[newTokenIds[i]] == address(0x0)) {
+                _tokenOwners[newTokenIds[i]] = msg.sender;
             }
             if (royaltyValues[i] > 0) {
                 _setTokenRoyalty(
-                    ids[i],
+                    newTokenIds[i],
                     royaltyRecipients[i],
                     royaltyValues[i]
                 );


### PR DESCRIPTION
Have added a counter that keeps track of next available token ID for minting. This will help with the UI integration allowing us to fetch the next known free token ID for new minting.

This logic also sets the token ID new token mints to default to the next available token ID, meaning if ID 10 is attempted to be minted new, but only tokens with ID 1-4 have currently been minted, the ID of 5 will be used.